### PR TITLE
Fix AsrManager.initialize(models:) renamed to loadModels(_:)

### DIFF
--- a/TypeWhisper/Services/Engine/ParakeetEngine.swift
+++ b/TypeWhisper/Services/Engine/ParakeetEngine.swift
@@ -39,7 +39,7 @@ final class ParakeetEngine: TranscriptionEngine, @unchecked Sendable {
             onPhaseChange?("loading")
 
             let manager = AsrManager(config: .default)
-            try await manager.initialize(models: models)
+            try await manager.loadModels(models)
             progress(0.90, nil)
             onPhaseChange?("prewarming")
 


### PR DESCRIPTION
FluidAudio 0.13.x renamed `AsrManager.initialize(models:)` to `loadModels(_:)` in https://github.com/FluidInference/FluidAudio/pull/494, breaking the build. Updated `ParakeetEngine.swift` to use the new API.

Tested on physical iPhone 16 Pro.