### PR TITLE
Add dictionary export/import for iOS

### DIFF
--- a/TypeWhisper/Services/DictionaryExporter.swift
+++ b/TypeWhisper/Services/DictionaryExporter.swift
@@ -1,0 +1,132 @@
+import Foundation
+import SwiftUI
+import UniformTypeIdentifiers
+
+enum DictionaryExporter {
+
+    struct ParsedEntry {
+        let type: DictionaryEntryType
+        let original: String
+        let replacement: String?
+        let caseSensitive: Bool
+        let isEnabled: Bool
+    }
+
+    struct ImportResult {
+        let imported: Int
+        let skipped: Int
+    }
+
+    // MARK: - Export
+
+    static func exportJSON(_ entries: [DictionaryEntry]) -> String {
+        let dicts: [[String: Any]] = entries.map { entry in
+            var dict: [String: Any] = [
+                "type": entry.type.rawValue,
+                "original": entry.original,
+                "caseSensitive": entry.caseSensitive,
+                "isEnabled": entry.isEnabled
+            ]
+            if let replacement = entry.replacement {
+                dict["replacement"] = replacement
+            }
+            return dict
+        }
+
+        guard let data = try? JSONSerialization.data(
+            withJSONObject: dicts,
+            options: [.prettyPrinted, .sortedKeys]
+        ), let json = String(data: data, encoding: .utf8) else {
+            return "[]"
+        }
+        return json
+    }
+
+    // MARK: - Import
+
+    static func parseJSON(_ data: Data) throws -> [ParsedEntry] {
+        guard let array = try JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+            throw DictionaryImportError.invalidFormat
+        }
+
+        return try array.map { dict in
+            guard let original = dict["original"] as? String, !original.isEmpty else {
+                throw DictionaryImportError.missingRequiredField("original")
+            }
+
+            let typeString = dict["type"] as? String ?? "term"
+            let type = DictionaryEntryType(rawValue: typeString) ?? .term
+            let replacement: String?
+
+            if type == .correction {
+                guard let correctionReplacement = dict["replacement"] as? String else {
+                    throw DictionaryImportError.missingRequiredField("replacement")
+                }
+                replacement = correctionReplacement
+            } else {
+                replacement = nil
+            }
+
+            return ParsedEntry(
+                type: type,
+                original: original,
+                replacement: replacement,
+                caseSensitive: dict["caseSensitive"] as? Bool ?? false,
+                isEnabled: dict["isEnabled"] as? Bool ?? true
+            )
+        }
+    }
+
+    @MainActor
+    static func importEntries(_ parsed: [ParsedEntry], into service: DictionaryService) -> ImportResult {
+        let before = service.entries.count
+
+        let items = parsed.map {
+            (type: $0.type, original: $0.original, replacement: $0.replacement,
+             caseSensitive: $0.caseSensitive, isEnabled: $0.isEnabled)
+        }
+        service.importEntries(items)
+
+        let after = service.entries.count
+        let imported = after - before
+        return ImportResult(imported: imported, skipped: parsed.count - imported)
+    }
+}
+
+struct DictionaryExportDocument: FileDocument {
+    static var readableContentTypes: [UTType] { [.json] }
+
+    let json: String
+
+    init(entries: [DictionaryEntry]) {
+        self.json = DictionaryExporter.exportJSON(entries)
+    }
+
+    init(configuration: ReadConfiguration) throws {
+        json = "[]"
+    }
+
+    func fileWrapper(configuration: WriteConfiguration) throws -> FileWrapper {
+        guard let data = json.data(using: .utf8) else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+        return FileWrapper(regularFileWithContents: data)
+    }
+}
+
+enum DictionaryImportError: LocalizedError {
+    case invalidFormat
+    case missingRequiredField(String)
+    case emptyFile
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidFormat:
+            return String(localized: "The file is not a valid dictionary JSON file.")
+        case .missingRequiredField(let field):
+            return String(localized: "Missing required field: \(field)")
+        case .emptyFile:
+            return String(localized: "The file contains no dictionary entries.")
+        }
+    }
+}

--- a/TypeWhisper/Services/DictionaryService.swift
+++ b/TypeWhisper/Services/DictionaryService.swift
@@ -141,6 +141,34 @@ class DictionaryService: ObservableObject {
         return result
     }
 
+    func importEntries(_ items: [(type: DictionaryEntryType, original: String, replacement: String?, caseSensitive: Bool, isEnabled: Bool)]) {
+        guard let context = modelContext, !items.isEmpty else { return }
+
+        var existingOriginals = Set(entries.map { "\($0.type.rawValue):\($0.original.lowercased())" })
+
+        for item in items {
+            let key = "\(item.type.rawValue):\(item.original.lowercased())"
+            guard !existingOriginals.contains(key) else { continue }
+
+            let entry = DictionaryEntry(
+                type: item.type,
+                original: item.original,
+                replacement: item.replacement,
+                caseSensitive: item.caseSensitive,
+                isEnabled: item.isEnabled
+            )
+            context.insert(entry)
+            existingOriginals.insert(key)
+        }
+
+        do {
+            try context.save()
+            loadEntries()
+        } catch {
+            print("DictionaryService: Failed to import entries: \(error.localizedDescription)")
+        }
+    }
+
     func learnCorrection(original: String, replacement: String) {
         guard original.lowercased() != replacement.lowercased() else { return }
         if entries.contains(where: { $0.type == .correction && $0.original.lowercased() == original.lowercased() }) { return }

--- a/TypeWhisper/ViewModels/DictionaryViewModel.swift
+++ b/TypeWhisper/ViewModels/DictionaryViewModel.swift
@@ -62,4 +62,22 @@ final class DictionaryViewModel: ObservableObject {
     func learnCorrection(original: String, replacement: String) {
         dictionaryService.learnCorrection(original: original, replacement: replacement)
     }
+
+    // MARK: - Export / Import
+
+    func exportDocument() -> DictionaryExportDocument {
+        DictionaryExportDocument(entries: entries)
+    }
+
+    func importDictionary(from url: URL) throws -> DictionaryExporter.ImportResult {
+        let accessing = url.startAccessingSecurityScopedResource()
+        defer { if accessing { url.stopAccessingSecurityScopedResource() } }
+
+        let data = try Data(contentsOf: url)
+        let parsed = try DictionaryExporter.parseJSON(data)
+        guard !parsed.isEmpty else {
+            throw DictionaryImportError.emptyFile
+        }
+        return DictionaryExporter.importEntries(parsed, into: dictionaryService)
+    }
 }

--- a/TypeWhisper/Views/Settings/DictionarySettingsView.swift
+++ b/TypeWhisper/Views/Settings/DictionarySettingsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UniformTypeIdentifiers
 
 struct DictionarySettingsView: View {
     @EnvironmentObject private var viewModel: DictionaryViewModel
@@ -8,6 +9,12 @@ struct DictionarySettingsView: View {
     @State private var newReplacement = ""
     @State private var newType: DictionaryEntryType = .term
     @State private var newCaseSensitive = false
+    @State private var showingImporter = false
+    @State private var showingExporter = false
+    @State private var exportDocument: DictionaryExportDocument?
+    @State private var importMessage: String?
+    @State private var error: String?
+    @State private var showingAlert = false
 
     var body: some View {
         List {
@@ -41,10 +48,62 @@ struct DictionarySettingsView: View {
                 }
             }
         }
+        .fileExporter(isPresented: $showingExporter, document: exportDocument, contentType: .json, defaultFilename: "dictionary-export.json") { result in
+            if case .failure(let err) = result {
+                error = err.localizedDescription
+                showingAlert = true
+            }
+        }
+        .fileImporter(isPresented: $showingImporter, allowedContentTypes: [.json]) { result in
+            switch result {
+            case .success(let url):
+                do {
+                    let importResult = try viewModel.importDictionary(from: url)
+                    if importResult.skipped > 0 {
+                        importMessage = "\(importResult.imported) entries imported, \(importResult.skipped) duplicates skipped."
+                    } else {
+                        importMessage = "\(importResult.imported) entries imported."
+                    }
+                } catch {
+                    self.error = error.localizedDescription
+                }
+                showingAlert = true
+            case .failure(let err):
+                error = err.localizedDescription
+                showingAlert = true
+            }
+        }
+        .alert("Dictionary Import", isPresented: $showingAlert) {
+            Button("OK") {
+                importMessage = nil
+                error = nil
+            }
+        } message: {
+            Text(importMessage ?? error ?? "")
+        }
         .searchable(text: $viewModel.searchQuery, prompt: "Search dictionary")
         .navigationTitle("Dictionary")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Menu {
+                    Button {
+                        exportDocument = viewModel.exportDocument()
+                        showingExporter = true
+                    } label: {
+                        Label(String(localized: "Export..."), systemImage: "square.and.arrow.up")
+                    }
+                    .disabled(viewModel.entries.isEmpty)
+
+                    Button {
+                        showingImporter = true
+                    } label: {
+                        Label(String(localized: "Import..."), systemImage: "square.and.arrow.down")
+                    }
+                } label: {
+                    Image(systemName: "ellipsis.circle")
+                }
+            }
             ToolbarItem(placement: .topBarTrailing) {
                 Button {
                     showingAddSheet = true


### PR DESCRIPTION
Closes #10

Ports dictionary export/import from the macOS app. Uses SwiftUI `.fileExporter` / `.fileImporter` as the iOS equivalents of `NSSavePanel` / `NSOpenPanel`.

**Note:** `DictionaryExporter.swift` is a new file and will need to be added to the Xcode project's build sources.